### PR TITLE
Move map to Google Maps JavaScript API v3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,3 @@
 name: Ember London
 markdown: kramdown
+google_maps_key: 'AIzaSyB2lK8UZhlsn0xGQUfNWAMHFrgc177HPOc'

--- a/_includes/map.html
+++ b/_includes/map.html
@@ -1,0 +1,27 @@
+<script type="text/javascript"
+    src="//maps.googleapis.com/maps/api/js?key={{site.google_maps_key}}">
+</script>
+<script type="text/javascript">
+  function initialize() {
+    var address = "{{ site.data.next-event.location }} ";
+    var geocoder = new google.maps.Geocoder();
+
+    geocoder.geocode( { 'address':  address }, function(results, status) {
+      if (status == google.maps.GeocoderStatus.OK) {
+        var latlng = results[0].geometry.location;
+        var mapOptions = {
+          scrollwheel: false,
+          center: latlng,
+          zoom: 15
+        };
+        var mapNode = document.getElementsByClassName('map')[0];
+        var map = new google.maps.Map(mapNode, mapOptions);
+        var marker = new google.maps.Marker({
+          position: latlng,
+          map: map
+        });
+      }
+    });
+  }
+  google.maps.event.addDomListener(window, 'load', initialize);
+</script>

--- a/_includes/next.html
+++ b/_includes/next.html
@@ -13,7 +13,7 @@
     <div class="column next-column">
       <h3>The Venue</h3>
       <div class="map-container" role="presentation" aria-hidden="true">
-        <iframe role="presentation" src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDbdA24xXumDDlD6MHP0CfZVY0tCB7S5QU&q={{site.data.next-event.location | uri_escape}}&zoom=15" height="100%" width="100%" frameborder="0" class="map"></iframe>
+        <div class="map"></div>
       </div>
       <p class="map-link"><a href="http://maps.google.com/?q={{site.data.next-event.location | uri_escape}}">{{site.data.next-event.location}}</a></p>
       <p>Kindly sponsored by <a href="http://www.sapient.com/en-gb/sapientnitro.html">SapientNitro</a></p>

--- a/css/main.css
+++ b/css/main.css
@@ -164,7 +164,7 @@ p { margin: 24px 0; }
   overflow: hidden;
 }
 
-.next-column .map-container iframe {
+.next-column .map-container .map {
   position: absolute;
   top:0;
   left: 0;

--- a/index.html
+++ b/index.html
@@ -27,3 +27,4 @@ title: The London Ember.js User Group
     </div>
   </footer>
 </div>
+{% include map.html %}


### PR DESCRIPTION
Reference: emberlondon/emberlondon.github.io#7

This uses the [Google Maps JavaScript API v3](https://developers.google.com/maps/documentation/javascript/) to generate the map, and explicitly disables scrollwheel. A couple of points worthy of noting:

- It seems CSS is clobbering the controls, they should appear on the left-hand side. (CSS not a speciality of mine)
- We lose the placeholder with the location name and there doesn't seem to be a way to re-include via the API.
- Once you change the API key, I'll retire mine.




